### PR TITLE
Feature/Elasticsearch and Kibana exit code

### DIFF
--- a/elastic-cluster/docker-compose.yaml
+++ b/elastic-cluster/docker-compose.yaml
@@ -205,6 +205,7 @@ services:
       test:
         - "CMD-SHELL"
         - |-
+          [ -f config/certs/ca/ca.crt ] &&
           [ -f config/certs/elasticsearch1/elasticsearch1.crt ] &&
           [ -f config/certs/elasticsearch1/elasticsearch1.key ] &&
           [ -f config/certs/elasticsearch2/elasticsearch2.crt ] &&
@@ -338,6 +339,9 @@ services:
     logging: *default-logging
 
   kibana:
+    depends_on:
+      setup:
+        condition: "service_healthy"
     image: *kibana-image
     mem_limit: "1024m"
     mem_reservation: "512m"

--- a/elastic-cluster/docker-compose.yaml
+++ b/elastic-cluster/docker-compose.yaml
@@ -333,6 +333,8 @@ services:
       ELASTIC_USERNAME: *elasticsearch-username
       ELASTIC_PASSWORD: *elasticsearch-password
       <<: *elasticsearch-master-nodes
+    ports:
+      - "9204:9200"
     volumes:
       - *elasticsearch-certs-volume
       - "elasticsearch4-data:/usr/share/elasticsearch/data"

--- a/elastic-cluster/docker-compose.yaml
+++ b/elastic-cluster/docker-compose.yaml
@@ -199,7 +199,8 @@ services:
           -d "{\"password\":\"$${KIBANA_PASSWORD}\"}" | grep -q "^{}"; do
           sleep 10;
         done &&
-        echo "All done!"
+        echo "All done!" &&
+        sleep 10
     healthcheck:
       # noinspection ComposeUnknownValues
       test:
@@ -213,7 +214,7 @@ services:
           [ -f config/certs/elasticsearch3/elasticsearch3.key ] &&
           [ -f config/certs/elasticsearch4/elasticsearch4.crt ] &&
           [ -f config/certs/elasticsearch4/elasticsearch4.key ]
-      interval: 10s
+      interval: 1s
       timeout: 5s
       retries: 120
     environment:
@@ -338,6 +339,9 @@ services:
     logging: *default-logging
 
   kibana:
+    depends_on:
+      setup:
+        condition: "service_healthy"
     image: *kibana-image
     mem_limit: "1024m"
     mem_reservation: "512m"

--- a/elastic-cluster/docker-compose.yaml
+++ b/elastic-cluster/docker-compose.yaml
@@ -66,6 +66,20 @@ x-elasticsearch-api-endpoint: &elasticsearch-api-endpoint
   "https://elasticsearch4:9200"
 
 # noinspection ComposeUnknownKeys
+x-elasticsearch-entrypoint: &elasticsearch-entrypoint
+  - "/bin/tini"
+  - "-e"
+  - "130"
+  - "-e"
+  - "143"
+  - "--"
+
+# noinspection ComposeUnknownKeys
+x-elasticsearch-command: &elasticsearch-command
+  - "/usr/local/bin/docker-entrypoint.sh"
+  - "eswrapper"
+
+# noinspection ComposeUnknownKeys
 x-elasticsearch-healthcheck: &elasticsearch-healthcheck
   test:
     - "CMD-SHELL"
@@ -211,6 +225,8 @@ services:
     image: *elasticsearch-image
     <<: *elasticsearch-data-node-limits
     ulimits: *default-ulimits
+    entrypoint: *elasticsearch-entrypoint
+    command: *elasticsearch-command
     healthcheck: *elasticsearch-healthcheck
     environment:
       node.name: "elasticsearch1"
@@ -233,6 +249,8 @@ services:
     image: *elasticsearch-image
     <<: *elasticsearch-data-node-limits
     ulimits: *default-ulimits
+    entrypoint: *elasticsearch-entrypoint
+    command: *elasticsearch-command
     healthcheck: *elasticsearch-healthcheck
     environment:
       node.name: "elasticsearch2"
@@ -255,6 +273,8 @@ services:
     image: *elasticsearch-image
     <<: *elasticsearch-data-node-limits
     ulimits: *default-ulimits
+    entrypoint: *elasticsearch-entrypoint
+    command: *elasticsearch-command
     healthcheck: *elasticsearch-healthcheck
     environment:
       node.name: "elasticsearch3"
@@ -278,6 +298,8 @@ services:
     mem_limit: "1024m"
     mem_reservation: "512m"
     ulimits: *default-ulimits
+    entrypoint: *elasticsearch-entrypoint
+    command: *elasticsearch-command
     healthcheck: *elasticsearch-healthcheck
     environment:
       node.name: "elasticsearch4"

--- a/elastic-cluster/docker-compose.yaml
+++ b/elastic-cluster/docker-compose.yaml
@@ -89,6 +89,19 @@ x-elasticsearch-healthcheck: &elasticsearch-healthcheck
   retries: 20
 
 # noinspection ComposeUnknownKeys
+x-kibana-entrypoint: &kibana-entrypoint
+  - "/bin/tini"
+  - "-e"
+  - "130"
+  - "-e"
+  - "143"
+  - "--"
+
+# noinspection ComposeUnknownKeys
+x-kibana-command: &kibana-command
+  - "/usr/local/bin/kibana-docker"
+
+# noinspection ComposeUnknownKeys
 x-kibana-healthcheck: &kibana-healthcheck
   test:
     - "CMD-SHELL"
@@ -329,6 +342,8 @@ services:
     mem_limit: "1024m"
     mem_reservation: "512m"
     ulimits: *default-ulimits
+    entrypoint: *kibana-entrypoint
+    command: *kibana-command
     healthcheck: *kibana-healthcheck
     environment:
       SERVER_PUBLICBASEURL: "http://localhost:5601"

--- a/elastic-cluster/docker-compose.yaml
+++ b/elastic-cluster/docker-compose.yaml
@@ -205,7 +205,6 @@ services:
       test:
         - "CMD-SHELL"
         - |-
-          [ -f config/certs/ca/ca.crt ] &&
           [ -f config/certs/elasticsearch1/elasticsearch1.crt ] &&
           [ -f config/certs/elasticsearch1/elasticsearch1.key ] &&
           [ -f config/certs/elasticsearch2/elasticsearch2.crt ] &&
@@ -339,9 +338,6 @@ services:
     logging: *default-logging
 
   kibana:
-    depends_on:
-      setup:
-        condition: "service_healthy"
     image: *kibana-image
     mem_limit: "1024m"
     mem_reservation: "512m"

--- a/elastic-cluster/init.sh
+++ b/elastic-cluster/init.sh
@@ -6,7 +6,7 @@ DOCKER_HOST='localhost'
 
 elasticsearch_api_user='elastic'
 elasticsearch_api_password='elastic'
-elasticsearch_api_url_base="https://${DOCKER_HOST}:9201"
+elasticsearch_api_url_base="https://${DOCKER_HOST}:9204"
 kibana_api_url_base="http://${DOCKER_HOST}:5601"
 elasticsearch_index_alias="fluent-bit"
 elasticsearch_index_name="${elasticsearch_index_alias}-000001"

--- a/single-node-elastic-cluster/docker-compose.yaml
+++ b/single-node-elastic-cluster/docker-compose.yaml
@@ -37,6 +37,20 @@ x-elasticsearch-api-endpoint: &elasticsearch-api-endpoint
   "http://elasticsearch:9200"
 
 # noinspection ComposeUnknownKeys
+x-elasticsearch-entrypoint: &elasticsearch-entrypoint
+  - "/bin/tini"
+  - "-e"
+  - "130"
+  - "-e"
+  - "143"
+  - "--"
+
+# noinspection ComposeUnknownKeys
+x-elasticsearch-command: &elasticsearch-command
+  - "/usr/local/bin/docker-entrypoint.sh"
+  - "eswrapper"
+
+# noinspection ComposeUnknownKeys
 x-elasticsearch-healthcheck: &elasticsearch-healthcheck
   test:
     - "CMD-SHELL"
@@ -90,6 +104,8 @@ services:
     mem_limit: "2048m"
     mem_reservation: "1024m"
     ulimits: *default-ulimits
+    entrypoint: *elasticsearch-entrypoint
+    command: *elasticsearch-command
     healthcheck: *elasticsearch-healthcheck
     environment:
       discovery.type: "single-node"

--- a/single-node-elastic-cluster/docker-compose.yaml
+++ b/single-node-elastic-cluster/docker-compose.yaml
@@ -60,6 +60,19 @@ x-elasticsearch-healthcheck: &elasticsearch-healthcheck
   retries: 20
 
 # noinspection ComposeUnknownKeys
+x-kibana-entrypoint: &kibana-entrypoint
+  - "/bin/tini"
+  - "-e"
+  - "130"
+  - "-e"
+  - "143"
+  - "--"
+
+# noinspection ComposeUnknownKeys
+x-kibana-command: &kibana-command
+  - "/usr/local/bin/kibana-docker"
+
+# noinspection ComposeUnknownKeys
 x-kibana-healthcheck: &kibana-healthcheck
   test:
     - "CMD-SHELL"
@@ -124,6 +137,8 @@ services:
     mem_limit: "1024m"
     mem_reservation: "512m"
     ulimits: *default-ulimits
+    entrypoint: *kibana-entrypoint
+    command: *kibana-command
     healthcheck: *kibana-healthcheck
     environment:
       SERVER_PUBLICBASEURL: "http://localhost:5601"


### PR DESCRIPTION
* Overwriting exit code to zero for Elasticsearch when it's stopped with SITGTERM.
* Overwriting exit code to zero for Kibana when it's stopped with SITGTERM.
* Enhanced start of Kibana in Docker Compose project for clustered Elastic.
* Exposing and using in init script Elasticsearch coordinating node.