### PR TITLE
Feature/Elasticsearch load balancer

### DIFF
--- a/elastic-cluster/README.md
+++ b/elastic-cluster/README.md
@@ -67,6 +67,12 @@ Docker Compose project for Elastic cluster consisting of:
                       │   elasticsearch-balancer    │
                       │                             │
                       │          (HAProxy)          │
+                      └──────────────▲──────────────┘
+                                     │
+                      ┌──────────────┴──────────────┐
+                      │                             │
+                      │     Elasticsearch user      │
+                      │                             │
                       └─────────────────────────────┘
 ```
 


### PR DESCRIPTION
Extended README with usage of balancer in front of Elasticsearch coordinating only nodes.